### PR TITLE
Missing return statement on wav check

### DIFF
--- a/encode.c
+++ b/encode.c
@@ -76,6 +76,7 @@ int main(int argc,char **argv)
 			return -1;
 		default:
 			fprintf(stderr,"Some error occured. Exiting.......\n");
+			return -1;
 	}
 
 	//Print media info


### PR DESCRIPTION
The default case of the switch statement doesn't have a return to exit like it claims it does. `check_wav_file` doesn't return any other error code other than the ones caught, but it never hurts to be safe.
